### PR TITLE
make sure to use ints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: roptim
 Type: Package
 Title: General Purpose Optimization in R using C++
-Version: 0.1.5
+Version: 0.1.6
 Author: Yi Pan [aut, cre]
 Maintainer: Yi Pan <ypan1988@gmail.com>
 Description: Perform general purpose optimization in R using C++. A unified 

--- a/inst/include/roptim.h
+++ b/inst/include/roptim.h
@@ -237,7 +237,7 @@ inline void Roptim<Derived>::minimize(Derived &func, arma::vec &par) {
     grcount_ = 0;
 
   } else if (method_ == "BFGS") {
-    arma::ivec mask = arma::ones<arma::ivec>(npar);
+    arma::Col<int> mask = arma::ones<arma::Col<int>>(npar);
     vmmin(npar, dpar.memptr(), &val_, fminfn, fmingr, control.maxit,
           control.trace, mask.memptr(), control.abstol, control.reltol,
           control.REPORT, &func, &fncount_, &grcount_, &fail_);
@@ -252,7 +252,7 @@ inline void Roptim<Derived>::minimize(Derived &func, arma::vec &par) {
   } else if (method_ == "L-BFGS-B") {
     arma::vec lower(npar);
     arma::vec upper(npar);
-    arma::ivec nbd = arma::zeros<arma::ivec>(npar);
+    arma::Col<int> nbd = arma::zeros<arma::Col<int>>(npar);
     char msg[60];
 
     for (std::size_t i = 0; i != npar; ++i) {

--- a/src/roptim.h
+++ b/src/roptim.h
@@ -237,7 +237,7 @@ inline void Roptim<Derived>::minimize(Derived &func, arma::vec &par) {
     grcount_ = 0;
 
   } else if (method_ == "BFGS") {
-    arma::ivec mask = arma::ones<arma::ivec>(npar);
+    arma::Col<int> mask = arma::ones<arma::Col<int>>(npar);
     vmmin(npar, dpar.memptr(), &val_, fminfn, fmingr, control.maxit,
           control.trace, mask.memptr(), control.abstol, control.reltol,
           control.REPORT, &func, &fncount_, &grcount_, &fail_);
@@ -252,7 +252,7 @@ inline void Roptim<Derived>::minimize(Derived &func, arma::vec &par) {
   } else if (method_ == "L-BFGS-B") {
     arma::vec lower(npar);
     arma::vec upper(npar);
-    arma::ivec nbd = arma::zeros<arma::ivec>(npar);
+    arma::Col<int> nbd = arma::zeros<arma::Col<int>>(npar);
     char msg[60];
 
     for (std::size_t i = 0; i != npar; ++i) {


### PR DESCRIPTION
There is a compilation problem when using `arma::ivec` (aka `arma::Col<sword>`) together with `#define ARMA_64BIT_WORD 1` (which is quite common).

So I just replaced the 4 instances of `ivec` to explicitly use ints, and it solved the issue.