### PR TITLE
Remove obsolete CXX_STD = CXX11 to allow Armadillo 15.0.x migration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ Description: Perform general purpose optimization in R using C++. A unified
     optim().
 License: GPL (>= 2)
 Encoding: UTF-8
-SystemRequirements: C++11
 Imports: Rcpp (>= 0.12.14)
 LinkingTo: Rcpp, RcppArmadillo
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard. For most packages, adapting to it can be very simple, and yours is one of them. In this PR we simply remove the declaration from DESCRIPTION -- and no other changes are needed.

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below for context, and notably [#489](https://github.com/RcppCore/RcppArmadillo/issues/489) for this first wave of PRs. It would be terrific if you could make an upload to CRAN 'soon' to remove the reliance on C++11 which we needed in the past, but which is by now a hindrance. Please do not hesitate to reach out if I can assist in any way or clarify matters.

/cc @kurthornik